### PR TITLE
rpc服务增加重定向host参数

### DIFF
--- a/src/Listener/RegisterServiceListener.php
+++ b/src/Listener/RegisterServiceListener.php
@@ -118,6 +118,10 @@ class RegisterServiceListener implements ListenerInterface
             if (in_array($host, ['0.0.0.0', 'localhost'])) {
                 $host = $this->ipReader->read();
             }
+            /* 新增重定向host地址（一般程序位于DOCKER中取不到宿主机真实地址可用） */
+            if (! empty($server['redirect_host'])) {
+                $host = $server['redirect_host'];
+            }
             if (! filter_var($host, FILTER_VALIDATE_IP)) {
                 throw new \InvalidArgumentException(sprintf('Invalid host %s', $host));
             }


### PR DESCRIPTION
一般在docker中部署服务的时候，会获取不到宿主机的真实IP地址。让发布服务可重定向增加容错率。